### PR TITLE
feat: improve GitHub Projects setup and add test plan from acceptance criteria

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,10 @@ Example: `feat[ENV-123](auth): add OAuth2 login`
 2. Commit: `devflow commit`
 3. When ready: `devflow pr` (auto-moves issue to "In Review")
 
+## Test Plans
+
+When creating a branch from an issue with `## Acceptance Criteria`, devflow will offer to use those as test plan steps. These appear in the PR description.
+
 ## Dry Run
 
 Use `--dry-run` to preview any command without executing:


### PR DESCRIPTION
## Summary

- Fixed invalid OAuth scope (`write:project` → `project`) for GitHub Projects integration
- Improved project setup UX with better explanations and repo-linked project filtering
- Added ability to create and link new GitHub Projects during init
- Added test plan auto-population from issue Acceptance Criteria

## Changes

### `devflow init` improvements:
- Better explanation of what project integration enables before asking for permissions
- Show only projects linked to the current repo (not all owner projects)
- Option to create a new project with custom name (default: `{repo-name} Board`)
- Auto-link newly created projects to the repo

### `devflow branch` improvements:
- Parse `## Acceptance Criteria` section from issue body
- Display AC items and offer to use them as test plan steps
- Cleaner prompt flow for test plan creation

### New tests:
- Added 8 tests for `parseAcceptanceCriteria()` function

## Test plan

- [x] Run `devflow init` and test project setup flow
- [x] Create branch from issue with acceptance criteria
- [x] Verify test plan is saved and appears in PR
- [x] All 136 tests pass

Closes #11