### PR TITLE
feat(core): generate Claude Code wrapper skill via init/update

### DIFF
--- a/.claude/skills/devflow-usage/SKILL.md
+++ b/.claude/skills/devflow-usage/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: devflow-usage
+description: MANDATORY when working in any devflow-managed repo (one with a .devflow/config.json). Always use devflow commands instead of raw git/gh — `devflow branch` over `git checkout -b`, `devflow commit` over `git commit`, `devflow pr` over `gh pr create`. Never push directly to main; all changes go through PRs. Full command reference and non-interactive flag examples live in .devflow/AI_INSTRUCTIONS.md.
+---
+
+# DevFlow Usage
+
+This repo uses [devflow](https://github.com/alejandrochvs/devflow-cli) for Git workflow automation. Apply these rules whenever making changes.
+
+## Core rules
+
+1. **Never push directly to main.** All changes go through pull requests, even small fixes.
+2. **Use devflow commands, not raw git/gh:**
+   - Branches: `devflow branch` (not `git checkout -b`)
+   - Commits: `devflow commit` (not `git commit`)
+   - PRs: `devflow pr` (not `gh pr create`)
+   - Issues: `devflow issue` / `devflow issues` (not `gh issue ...`)
+3. **Issue-first workflow** (when a project board is configured):
+   - `devflow issues` to see Todo / In Progress
+   - `devflow issues --work --issue <N> --yes` to start work (assigns, moves to In Progress, creates branch)
+4. **Commit format:** `{type}[{ticket}]({scope}): {message}` — e.g. `feat[123](auth): add OAuth2 login`. The exact format is configured in `.devflow/config.json` (`commitFormat` field).
+5. **Branch format:** `{type}/{ticket}_{description}` — e.g. `feat/123_add-login`. Configurable in `.devflow/config.json` (`branchFormat`).
+6. **Press `Escape`** to go back a step in any multi-step prompt.
+7. **Use `--dry-run`** to preview any command without executing.
+
+## Non-interactive mode for AI agents
+
+Append `--yes` to skip all confirmation prompts. Each command also accepts content flags so prompts can be skipped entirely:
+
+```bash
+devflow branch --type feat --ticket 123 --description "add-login" --yes
+devflow commit --type feat --scope auth --message "add login" --all --yes
+devflow pr --title "Add login" --summary "Implements login UI" --yes
+```
+
+Full per-command non-interactive examples live in `.devflow/AI_INSTRUCTIONS.md`.
+
+## Full reference
+
+For everything beyond the basics above — Quick Reference table, all command flags, common workflows, edge cases like merged/closed PRs — read `.devflow/AI_INSTRUCTIONS.md`. Treat that file as canonical.
+
+## Why a skill plus an instructions file?
+
+`.devflow/AI_INSTRUCTIONS.md` is the canonical, agent-agnostic reference (read by Cursor, Copilot, and any other AI tool). This skill is a Claude-Code-specific wrapper that surfaces the rules in Claude's available-skills list so they're always discoverable. Both files stay in sync via `devflow update`.

--- a/.claude/skills/docs-sync/SKILL.md
+++ b/.claude/skills/docs-sync/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: devflow-docs-sync
+description: MANDATORY when editing any file under src/ in the devflow repo (especially src/commands/, src/config.ts, src/index.ts, src/providers/, src/plugins.ts, src/monorepo.ts). Identifies which documentation surfaces need updating based on the project's source-to-docs map, proposes the edits in the same change, and bumps .devflow/version.json when .devflow/AI_INSTRUCTIONS.md is touched. Invoke BEFORE finalizing any code edit so docs ship with the change, not after.
+---
+
+# DevFlow Documentation Sync
+
+Whenever you change a file under `src/`, run this skill to check which docs need updating, propose and apply the edits, and ensure the four parallel documentation surfaces stay in sync with the code.
+
+**Do not skip or defer.** Docs that lag behind a commit rot immediately; the right time to fix them is in the same change.
+
+---
+
+## When to invoke
+
+- Any edit to `src/commands/<X>.ts` (new flag, new flow step, changed behavior)
+- Any edit to `src/config.ts` (new config field, changed schema, new preset)
+- Any edit to `src/index.ts` (new command wired up, new alias)
+- Any edit to `src/providers/tickets.ts` or `src/providers/projects.ts`
+- Any edit to `src/plugins.ts`, `src/monorepo.ts`, `src/test-plan.ts`, `src/update-notifier.ts`
+- Any AI-facing change: new interactive prompt, new `--flag`, changed flow, escape key behavior
+
+Invoke **before** writing the commit message so the doc edits are part of the same commit.
+
+---
+
+## Documentation surfaces
+
+There are four primary surfaces that must stay in sync, plus secondary ones:
+
+### Primary (must always check)
+1. **`README.md`** — `## Commands` section (L45+) with `### devflow <name>` heading per command, plus aliases table at L430–451.
+2. **`CLAUDE.md`** — Quick Reference table at L25–38 (only lists core commands: status, issues, issue, branch, commit, pr, amend, comments).
+3. **`.devflow/AI_INSTRUCTIONS.md`** — Quick Reference table (L4–13) + one non-interactive block per command (`### Branch Command`, `### Commit Command`, etc.).
+4. **`docs/commands/<name>.md`** — one file per command, sidebar in `docs/.vitepress/config.ts` L20–74 is the registry (must be updated when a new doc file is added).
+
+### Secondary (check when relevant)
+- `docs/configuration.md` — config schema tables
+- `docs/getting-started.md` — aliases table at L104–125
+- `docs/integrations.md` — CI, Husky, AI agent integration
+- `docs/plugins.md` — plugin API
+- `docs/workflows/release.md` — release ritual
+- `CHANGELOG.md` — `[Unreleased]` section, grouped by `### Features` / `### Bug Fixes` / `### Documentation`
+- `.github/pull_request_template.md` — checklist (fyi only, not edited by this skill)
+
+---
+
+## Source-to-docs map
+
+| If you changed… | Update these surfaces |
+|---|---|
+| `src/commands/<X>.ts` (behavior/flags) | `docs/commands/<X>.md` (flow + options table), README `### devflow <X>` section, AI_INSTRUCTIONS.md per-command block |
+| `src/commands/<X>.ts` (new command, no prior docs) | See **"New command" scenario** below |
+| `src/config.ts` (schema, new field) | `docs/configuration.md` Config Options table, README "Config Options" L518–534, `docs/commands/lint-config.md` checks list |
+| `src/index.ts` (new alias or command registration) | README aliases table L430–451, `docs/getting-started.md` aliases table L104–125, CLAUDE.md Quick Reference (core commands only), sidebar `docs/.vitepress/config.ts` |
+| `src/providers/tickets.ts` or `src/providers/projects.ts` | `docs/configuration.md` "Ticket Provider" section, README "Config Options", `docs/commands/branch.md` "GitHub Issues Integration", `docs/commands/pr.md` "GitHub Issues Auto-Close" |
+| `src/plugins.ts` | `docs/plugins.md`, README "## Plugins" L637–667 |
+| `src/monorepo.ts` | `docs/configuration.md` "## Monorepo Awareness", README L553–563 |
+| `src/test-plan.ts` | `docs/commands/test-plan.md`, README L144–162 |
+| `src/update-notifier.ts` | README "## Update Notifications" L629–635 |
+| `.devflow/AI_INSTRUCTIONS.md` (any change) | Bump `.devflow/version.json` — see version bump section below |
+| `src/git.ts` | No doc surface — skip |
+
+---
+
+## Scenario: new command added
+
+When a new `src/commands/<X>.ts` file is created or a new command is wired in `src/index.ts`, update these 8 surfaces in order:
+
+1. **Create `docs/commands/<X>.md`** using the standard template:
+   ```markdown
+   # devflow <name>
+
+   **Alias:** `devflow <alias>`
+
+   <brief description>
+
+   ## Flow
+   ...
+
+   ## Options
+
+   | Option | Description |
+   |--------|-------------|
+   | ... | ... |
+   ```
+2. **Add to sidebar** in `docs/.vitepress/config.ts` under the appropriate group (Core Commands / Workflow / Info / Setup).
+3. **Add `### devflow <X>`** section in README.md under `## Commands`.
+4. **Add row** to README.md aliases table (L430–451).
+5. **Add row** to `docs/getting-started.md` aliases table (L104–125).
+6. **Add non-interactive block** to `.devflow/AI_INSTRUCTIONS.md` following the `### <Name> Command` pattern.
+7. **Add row** to AI_INSTRUCTIONS.md Quick Reference table (L4–13).
+8. **Add row** to CLAUDE.md Quick Reference table if it's a core workflow command.
+9. **Add entry** to `CHANGELOG.md` `[Unreleased]` `### Features` section.
+
+---
+
+## Scenario: behavior change in existing command
+
+For any flag change, new prompt, removed option, or changed default:
+
+1. Read `docs/commands/<X>.md` and verify the `## Flow` and `## Options` table are accurate.
+2. Read README.md `### devflow <X>` subsection and verify options and examples.
+3. Read AI_INSTRUCTIONS.md per-command block and verify the non-interactive flag examples still work.
+4. If the change is user-visible, add an entry to `CHANGELOG.md` `[Unreleased]` under `### Features` or `### Bug Fixes`.
+
+---
+
+## Process to follow
+
+1. **Identify changed files** — list files edited in this conversation (or run `git diff --name-only HEAD`).
+2. **Look up rows** in the source-to-docs map above.
+3. **Read each named doc surface** and compare against the actual new code.
+4. **Propose a diff plan** — tell the user which files need updating and what specifically changes. Get confirmation if the scope is large.
+5. **Apply the edits.**
+6. **Bump version.json** if AI_INSTRUCTIONS.md was touched (see below).
+7. **Check CHANGELOG** — if a `feat:` or `fix:` commit is being prepared, ensure `[Unreleased]` has a matching entry.
+
+---
+
+## Bumping .devflow/version.json
+
+When `.devflow/AI_INSTRUCTIONS.md` is modified, bump `.devflow/version.json` to match the version in `package.json`:
+
+```json
+{
+  "cliVersion": "<package.json version>",
+  "generatedAt": "<current ISO date>",
+  "files": {
+    "aiInstructions": "<package.json version>"
+  }
+}
+```
+
+Read `package.json` for the current version, then overwrite `version.json` with the bumped values.
+
+---
+
+## Known drift (self-test — flag on first invocation)
+
+These doc gaps exist in the repo right now. Flag them when relevant to the current change; fix them if the current change touches the area:
+
+| Drift item | Fix |
+|---|---|
+| `src/commands/issues.ts` exists; `docs/commands/issues.md` is missing | Create the file; add to sidebar |
+| `docs/.vitepress/config.ts` sidebar has no entry for `issues` | Add it |
+| `.devflow/version.json` `cliVersion: 1.6.1`; `package.json: 1.7.0` | Bump after any AI_INSTRUCTIONS.md touch |
+| "Press Escape to go back" is in AI_INSTRUCTIONS.md and getting-started.md but not README | Add one-liner to README `## Commands` intro |
+| CLAUDE.md Quick Reference has 9 rows; AI_INSTRUCTIONS.md has 7 rows | Reconcile — CLAUDE.md is the authoritative core-command list |
+
+Only fix these proactively if the current edit touches the same file or area. Otherwise, just call them out.
+
+---
+
+## Out of scope
+
+- `src/git.ts` — internal helpers only, no user-facing doc surface.
+- `.publishing_strategy/` — marketing drafts, not product docs.
+- `roadmap/*.md` — only update if the change introduces a new provider integration.
+- `release_notes.md` — regenerated each release by `devflow release`, do not hand-edit.
+- `CODE_OF_CONDUCT.md`, `SECURITY.md` — not feature-related.

--- a/.devflow/AI_INSTRUCTIONS.md
+++ b/.devflow/AI_INSTRUCTIONS.md
@@ -4,12 +4,14 @@
 
 | Task | Command |
 |------|---------|
+| Check status | `devflow status` |
+| List project issues | `devflow issues` |
+| Start work on issue | `devflow issues --work` |
 | New branch | `devflow branch` |
 | Commit changes | `devflow commit` or `devflow commit -m "message"` |
 | Create/update PR | `devflow pr` |
 | Create issue | `devflow issue` |
 | Amend last commit | `devflow amend` |
-| Check status | `devflow status` |
 | View PR comments | `devflow comments` |
 
 ## Rules for AI Agents
@@ -56,10 +58,19 @@ devflow commit --type fix --message "fix typo" --files "src/app.ts,src/index.ts"
 devflow commit --type feat --message "add API" --breaking --breaking-desc "Changes API format" --yes
 ```
 
+### Issues Command
+```bash
+devflow issues
+devflow issues --status in-progress
+devflow issues --available
+devflow issues --work --issue 42 --branch-desc "add-auth" --yes
+```
+
 ### PR Command
 ```bash
 devflow pr --title "Add OAuth2 login" --summary "Implements OAuth2 flow" --yes
 devflow pr --title "Feature X" --base develop --ready --yes
+# If a merged or closed PR exists on the branch, --yes auto-creates a new PR
 ```
 
 ### Issue Command

--- a/.devflow/version.json
+++ b/.devflow/version.json
@@ -1,7 +1,7 @@
 {
-  "cliVersion": "1.6.1",
-  "generatedAt": "2026-02-11T00:27:15.938Z",
+  "cliVersion": "1.7.0",
+  "generatedAt": "2026-04-27T00:00:00.000Z",
   "files": {
-    "aiInstructions": "1.6.1"
+    "aiInstructions": "1.7.0"
   }
 }

--- a/.devflow/version.json
+++ b/.devflow/version.json
@@ -2,6 +2,7 @@
   "cliVersion": "1.7.0",
   "generatedAt": "2026-04-27T00:00:00.000Z",
   "files": {
-    "aiInstructions": "1.7.0"
+    "aiInstructions": "1.7.0",
+    "claudeSkill": "1.7.0"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **pr** — Gracefully handle merged and closed PRs: merged branch prompts to create a new PR; closed branch offers reopen-and-update or create-new. `--yes` auto-creates in both cases.
+
+### Documentation
+
+- Add `docs/commands/issues.md` (previously missing)
+- Add `issues` to VitePress sidebar
+- Add Escape back-navigation tip to README
+- Sync AI_INSTRUCTIONS.md Quick Reference with CLAUDE.md (add `issues`, `issues --work`)
+- Bump `.devflow/version.json` to 1.7.0
+
 ## [1.7.0] - 2026-02-11
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Features
+
+- **init / update** — Generate a Claude Code wrapper skill at `.claude/skills/devflow-usage/SKILL.md` alongside `.devflow/AI_INSTRUCTIONS.md`. The skill surfaces devflow rules in Claude's available-skills list; AI_INSTRUCTIONS.md remains the canonical agent-agnostic reference for Cursor, Copilot, and other tools. Both files stay in sync via `devflow update`.
+
 ### Bug Fixes
 
 - **pr** — Gracefully handle merged and closed PRs: merged branch prompts to create a new PR; closed branch offers reopen-and-update or create-new. `--yes` auto-creates in both cases.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Or add scripts to your `package.json`:
 
 ## Commands
 
+> **Tip:** In any multi-step command, press **Escape** to go back to the previous step.
+
 ### `devflow init`
 
 Interactive setup wizard that configures your entire project. Walks you through:
@@ -116,15 +118,18 @@ The `!` after the ticket indicates a breaking change.
 Create or update a pull request with an auto-filled template.
 
 **Flow:**
-1. Checks if a PR already exists for the current branch (offers to update)
+1. Checks if a PR already exists for the current branch:
+   - **Open** — offers to update it
+   - **Merged** — asks whether to create a new PR
+   - **Closed** — asks to reopen and update, or create a new PR
 2. Infers the base branch (closest remote branch by merge-base)
 3. Enter PR title (pre-filled from branch description)
 4. Enter optional summary
 5. Preview PR body with template
-6. Confirm and create/update
+6. Confirm and create/update/reopen
 
 **Features:**
-- Auto-detects existing PRs and offers update flow
+- Auto-detects existing PRs; handles open, merged, and closed states
 - Infers base branch using `git merge-base` comparison
 - Pre-fills commit list in the summary
 - Auto-labels from branch type (feat → `feature`, fix → `bug`, etc.)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
         text: 'Workflow',
         items: [
           { text: 'issue', link: '/commands/issue' },
+          { text: 'issues', link: '/commands/issues' },
           { text: 'release', link: '/commands/release' },
           { text: 'review', link: '/commands/review' },
           { text: 'comments', link: '/commands/comments' },

--- a/docs/commands/issues.md
+++ b/docs/commands/issues.md
@@ -1,0 +1,70 @@
+# issues
+
+List and manage issues from your GitHub Project board. Enables issue-first development with automatic status tracking.
+
+**Alias:** `devflow is`
+
+## Prerequisites
+
+- GitHub Project (v2) linked to your repository
+- `project` configuration in `.devflow/config.json`
+- `gh` CLI with project permissions (`gh auth refresh -s project`)
+
+## Flow
+
+1. Connects to your GitHub Project board
+2. Lists issues grouped by status (Todo, In Progress, In Review, Done)
+3. Optionally select an issue to start working on it
+
+With `--work`: assigns the issue to you, moves it to "In Progress", and creates a branch.
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--status <status>` | Filter by status: `todo`, `in-progress`, `in-review`, `done` |
+| `--available` | Show only unassigned Todo items |
+| `--work` | Start working on an issue (assign, move to In Progress, create branch) |
+| `--issue <number>` | Pre-select an issue number (used with `--work`) |
+| `--branch-desc <desc>` | Branch description slug (used with `--work --yes`) |
+| `--dry-run` | Preview actions without executing |
+| `--yes` | Skip confirmation prompts |
+
+## Examples
+
+```bash
+# List Todo and In Progress items
+devflow issues
+
+# Filter by status
+devflow issues --status todo
+devflow issues --status in-progress
+
+# Show unassigned Todo items
+devflow issues --available
+
+# Start working interactively (assigns, moves to In Progress, creates branch)
+devflow issues --work
+
+# Non-interactive: start work on a specific issue
+devflow issues --work --issue 42 --branch-desc "add-auth" --yes
+```
+
+## Issue-First Workflow
+
+```bash
+# 1. See available work
+devflow issues
+
+# 2. Pick an issue and start working
+devflow issues --work --issue 42 --yes
+
+# 3. Make changes and commit
+git add <files>
+devflow commit
+
+# 4. Create PR (auto-moves issue to "In Review")
+devflow pr
+```
+
+When you create a PR linked to an issue, devflow automatically moves the issue to "In Review" status on the project board.

--- a/docs/commands/pr.md
+++ b/docs/commands/pr.md
@@ -8,16 +8,19 @@ Create or update a pull request with an auto-filled template.
 
 ## Flow
 
-1. Checks if a PR already exists for the current branch (offers to update)
+1. Checks if a PR already exists for the current branch:
+   - **Open PR** — offers to update it
+   - **Merged PR** — asks whether to create a new PR
+   - **Closed PR** — asks whether to reopen and update, or create a new PR
 2. Infers the base branch (closest remote branch by merge-base)
 3. Enter PR title (pre-filled from branch description)
 4. Enter optional summary
 5. Preview PR body with template
-6. Confirm and create/update
+6. Confirm and create/update/reopen
 
 ## Features
 
-- Auto-detects existing PRs and offers update flow
+- Auto-detects existing PRs; handles open, merged, and closed states
 - Infers base branch using `git merge-base` comparison
 - Pre-fills commit list in the summary
 - Auto-labels from branch type (`feat` → `feature`, `fix` → `bug`, etc.)
@@ -52,4 +55,9 @@ This automatically closes the issue when the PR is merged.
 
 | Option | Description |
 |--------|-------------|
+| `--title <title>` | PR title (skips title prompt) |
+| `--summary <summary>` | PR summary text (skips summary prompt) |
+| `--base <branch>` | Base branch to merge into (skips base prompt) |
+| `--ready` | Create as ready for review instead of draft |
+| `--yes` | Skip all confirmation prompts; auto-creates new PR if existing one is merged/closed |
 | `--dry-run` | Preview the PR body without creating |

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -73,7 +73,14 @@ Help AI coding assistants (Claude Code, Cursor, GitHub Copilot, etc.) understand
 
 ### Claude Code
 
-Create a `CLAUDE.md` in your project root:
+Running `devflow init` automatically generates two files that work together:
+
+- **`.devflow/AI_INSTRUCTIONS.md`** — canonical agent-agnostic reference (full command list, non-interactive flags, workflows). Readable by Cursor, Copilot, and any other AI tool.
+- **`.claude/skills/devflow-usage/SKILL.md`** — Claude Code wrapper skill. Surfaces devflow rules in Claude's available-skills list so they're always discoverable. Points to `AI_INSTRUCTIONS.md` for the full reference.
+
+Run `devflow update` at any time to regenerate both files to the latest template.
+
+You can also create a `CLAUDE.md` in your project root for additional project-specific instructions:
 
 ```markdown
 # Claude Code Instructions

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -824,6 +824,53 @@ devflow amend           # If you need to add more changes
           }
         }
       }
+
+      // Generate Claude Code skill wrapper that points to AI_INSTRUCTIONS.md
+      const skillDir = resolve(cwd, ".claude/skills/devflow-usage");
+      mkdirSync(skillDir, { recursive: true });
+      const claudeSkill = `---
+name: devflow-usage
+description: MANDATORY when working in any devflow-managed repo (one with a .devflow/config.json). Always use devflow commands instead of raw git/gh — \`devflow branch\` over \`git checkout -b\`, \`devflow commit\` over \`git commit\`, \`devflow pr\` over \`gh pr create\`. Never push directly to main; all changes go through PRs. Full command reference and non-interactive flag examples live in .devflow/AI_INSTRUCTIONS.md.
+---
+
+# DevFlow Usage
+
+This repo uses [devflow](https://github.com/alejandrochvs/devflow-cli) for Git workflow automation. Apply these rules whenever making changes.
+
+## Core rules
+
+1. **Never push directly to main.** All changes go through pull requests, even small fixes.
+2. **Use devflow commands, not raw git/gh:**
+   - Branches: \`devflow branch\` (not \`git checkout -b\`)
+   - Commits: \`devflow commit\` (not \`git commit\`)
+   - PRs: \`devflow pr\` (not \`gh pr create\`)
+   - Issues: \`devflow issue\` / \`devflow issues\` (not \`gh issue ...\`)
+3. **Issue-first workflow** (when a project board is configured):
+   - \`devflow issues\` to see Todo / In Progress
+   - \`devflow issues --work --issue <N> --yes\` to start work
+4. **Commit format:** \`${commitFormat}\` — e.g. \`feat[123](auth): add OAuth2 login\`.
+5. **Branch format:** \`${branchFormat}\` — e.g. \`feat/123_add-login\`.
+6. **Press \`Escape\`** to go back a step in any multi-step prompt.
+7. **Use \`--dry-run\`** to preview any command without executing.
+
+## Non-interactive mode for AI agents
+
+Append \`--yes\` to skip all confirmation prompts. Each command also accepts content flags so prompts can be skipped entirely:
+
+\`\`\`bash
+devflow branch --type feat --ticket 123 --description "add-login" --yes
+devflow commit --type feat --scope auth --message "add login" --all --yes
+devflow pr --title "Add login" --summary "Implements login UI" --yes
+\`\`\`
+
+Full per-command non-interactive examples live in \`.devflow/AI_INSTRUCTIONS.md\`.
+
+## Full reference
+
+For everything beyond the basics above — Quick Reference table, all command flags, common workflows, edge cases like merged/closed PRs — read \`.devflow/AI_INSTRUCTIONS.md\`. Treat that file as canonical.
+`;
+      writeFileSync(resolve(skillDir, "SKILL.md"), claudeSkill);
+      console.log("✓ Created .claude/skills/devflow-usage/SKILL.md");
     }
 
     // 10. Write .devflow/config.json

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -77,9 +77,11 @@ function ensureLabel(label: { name: string; color: string }): void {
   }
 }
 
-function getExistingPr(): { url: string; number: number } | undefined {
+type ExistingPrState = "OPEN" | "MERGED" | "CLOSED";
+
+function getExistingPr(): { url: string; number: number; state: ExistingPrState } | undefined {
   try {
-    const result = execSync("gh pr view --json url,number", {
+    const result = execSync("gh pr view --json url,number,state", {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "ignore"],
     }).trim();
@@ -160,15 +162,52 @@ export async function prCommand(options: PrOptions = {}): Promise<void> {
     const { type, ticket, description } = parseBranch(branch);
     const existingPr = getExistingPr();
 
-    if (existingPr && !options.yes) {
-      console.log(`\n${cyan(`PR #${existingPr.number}`)} already exists: ${existingPr.url}`);
-      const shouldUpdate = await confirmWithBack({
-        message: "Update this PR?",
-        default: true,
-        showBack: false,
-      });
-      if (shouldUpdate !== true) {
-        process.exit(0);
+    type PrAction = "update" | "reopen" | "create";
+    let prAction: PrAction = existingPr?.state === "OPEN" ? "update" : "create";
+
+    if (existingPr) {
+      if (existingPr.state === "OPEN" && !options.yes) {
+        console.log(`\n${cyan(`PR #${existingPr.number}`)} already exists: ${existingPr.url}`);
+        const shouldUpdate = await confirmWithBack({
+          message: "Update this PR?",
+          default: true,
+          showBack: false,
+        });
+        if (shouldUpdate !== true) {
+          process.exit(0);
+        }
+      } else if (existingPr.state === "MERGED") {
+        if (!options.yes) {
+          console.log(`\n${cyan(`PR #${existingPr.number}`)} is already ${dim("merged")}: ${existingPr.url}`);
+          const proceed = await confirmWithBack({
+            message: "Create a new PR for this branch?",
+            default: true,
+            showBack: false,
+          });
+          if (proceed !== true) {
+            process.exit(0);
+          }
+        }
+        // prAction stays "create"
+      } else if (existingPr.state === "CLOSED") {
+        if (!options.yes) {
+          console.log(`\n${cyan(`PR #${existingPr.number}`)} is ${dim("closed")}: ${existingPr.url}`);
+          const choice = await selectWithBack({
+            message: "What would you like to do?",
+            choices: [
+              { value: "reopen", name: "Reopen and update existing PR" },
+              { value: "new", name: "Create a new PR" },
+              { value: "cancel", name: "Cancel" },
+            ],
+            default: "new",
+            showBack: false,
+          });
+          if (choice === BACK_VALUE || choice === "cancel") {
+            process.exit(0);
+          }
+          prAction = choice === "reopen" ? "reopen" : "create";
+        }
+        // under --yes: prAction stays "create"
       }
     }
 
@@ -305,8 +344,12 @@ export async function prCommand(options: PrOptions = {}): Promise<void> {
     const uniquePreviewLabels = [...new Set(previewLabels)];
 
     console.log(`\n${dim("───")} ${bold("PR Preview")} ${dim("───")}`);
-    if (existingPr) {
-      console.log(gray(`(Updating existing PR #${existingPr.number})`));
+    if (prAction === "update") {
+      console.log(gray(`(Updating existing PR #${existingPr!.number})`));
+    } else if (prAction === "reopen") {
+      console.log(gray(`(Reopening and updating PR #${existingPr!.number})`));
+    } else if (existingPr) {
+      console.log(gray(`(Creating new PR; previous PR #${existingPr.number} was ${existingPr.state.toLowerCase()})`));
     }
     console.log(`${dim("Title:")}    ${bold(title)}`);
     console.log(`${dim("Branch:")}   ${cyan(branch)} → ${cyan(base.trim())}`);
@@ -326,12 +369,18 @@ export async function prCommand(options: PrOptions = {}): Promise<void> {
 
     // Confirm (skip if --yes)
     if (!options.yes) {
+      const confirmMessage =
+        prAction === "update" ? `Update PR #${existingPr!.number}?` :
+        prAction === "reopen" ? `Reopen and update PR #${existingPr!.number}?` :
+        "Create this PR?";
+      const confirmYesLabel =
+        prAction === "update" ? "Yes, update PR" :
+        prAction === "reopen" ? "Yes, reopen and update" :
+        "Yes, create PR";
       const confirmResult = await selectWithBack({
-        message: existingPr
-          ? `Update PR #${existingPr.number}?`
-          : "Create this PR?",
+        message: confirmMessage,
         choices: [
-          { value: "yes", name: existingPr ? "Yes, update PR" : "Yes, create PR" },
+          { value: "yes", name: confirmYesLabel },
           { value: "no", name: "No, abort" },
         ],
         default: "yes",
@@ -381,12 +430,19 @@ export async function prCommand(options: PrOptions = {}): Promise<void> {
     // Draft flag (unless --ready is specified)
     const draftFlag = options.ready ? "" : " --draft";
 
-    if (existingPr) {
+    if (prAction === "reopen") {
+      execSync(`gh pr reopen ${existingPr!.number}`, { stdio: "inherit" });
       execSync(
-        `gh pr edit ${existingPr.number} --title ${JSON.stringify(title)} --body-file -${labelFlag ? ` --add-label ${labelFlag}` : ""}`,
+        `gh pr edit ${existingPr!.number} --title ${JSON.stringify(title)} --body-file -${labelFlag ? ` --add-label ${labelFlag}` : ""}`,
         { input: body, stdio: ["pipe", "inherit", "inherit"] }
       );
-      console.log(green(`✓ PR #${existingPr.number} updated: ${existingPr.url}`));
+      console.log(green(`✓ PR #${existingPr!.number} reopened and updated: ${existingPr!.url}`));
+    } else if (prAction === "update") {
+      execSync(
+        `gh pr edit ${existingPr!.number} --title ${JSON.stringify(title)} --body-file -${labelFlag ? ` --add-label ${labelFlag}` : ""}`,
+        { input: body, stdio: ["pipe", "inherit", "inherit"] }
+      );
+      console.log(green(`✓ PR #${existingPr!.number} updated: ${existingPr!.url}`));
     } else {
       execSync(
         `gh pr create${draftFlag} --title ${JSON.stringify(title)} --body-file - --base ${base.trim()} --head ${branch} --assignee @me${reviewerFlag}${labelFlag ? ` --label ${labelFlag}` : ""}`,

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -14,6 +14,48 @@ export interface UpdateOptions {
   dryRun?: boolean;
 }
 
+const CLAUDE_SKILL_TEMPLATE = `---
+name: devflow-usage
+description: MANDATORY when working in any devflow-managed repo (one with a .devflow/config.json). Always use devflow commands instead of raw git/gh — \`devflow branch\` over \`git checkout -b\`, \`devflow commit\` over \`git commit\`, \`devflow pr\` over \`gh pr create\`. Never push directly to main; all changes go through PRs. Full command reference and non-interactive flag examples live in .devflow/AI_INSTRUCTIONS.md.
+---
+
+# DevFlow Usage
+
+This repo uses [devflow](https://github.com/alejandrochvs/devflow-cli) for Git workflow automation. Apply these rules whenever making changes.
+
+## Core rules
+
+1. **Never push directly to main.** All changes go through pull requests, even small fixes.
+2. **Use devflow commands, not raw git/gh:**
+   - Branches: \`devflow branch\` (not \`git checkout -b\`)
+   - Commits: \`devflow commit\` (not \`git commit\`)
+   - PRs: \`devflow pr\` (not \`gh pr create\`)
+   - Issues: \`devflow issue\` / \`devflow issues\` (not \`gh issue ...\`)
+3. **Issue-first workflow** (when a project board is configured):
+   - \`devflow issues\` to see Todo / In Progress
+   - \`devflow issues --work --issue <N> --yes\` to start work
+4. **Commit format:** \`{type}[{ticket}]{breaking}({scope}): {message}\` — e.g. \`feat[123](auth): add OAuth2 login\`.
+5. **Branch format:** \`{type}/{ticket}_{description}\` — e.g. \`feat/123_add-login\`.
+6. **Press \`Escape\`** to go back a step in any multi-step prompt.
+7. **Use \`--dry-run\`** to preview any command without executing.
+
+## Non-interactive mode for AI agents
+
+Append \`--yes\` to skip all confirmation prompts. Each command also accepts content flags so prompts can be skipped entirely:
+
+\`\`\`bash
+devflow branch --type feat --ticket 123 --description "add-login" --yes
+devflow commit --type feat --scope auth --message "add login" --all --yes
+devflow pr --title "Add login" --summary "Implements login UI" --yes
+\`\`\`
+
+Full per-command non-interactive examples live in \`.devflow/AI_INSTRUCTIONS.md\`.
+
+## Full reference
+
+For everything beyond the basics above — Quick Reference table, all command flags, common workflows, edge cases like merged/closed PRs — read \`.devflow/AI_INSTRUCTIONS.md\`. Treat that file as canonical.
+`;
+
 const AI_INSTRUCTIONS_TEMPLATE = `# DevFlow - AI Agent Instructions
 
 ## Quick Reference
@@ -264,6 +306,45 @@ export async function updateCommand(options: UpdateOptions = {}): Promise<void> 
       } else {
         writeFileSync(aiInstructionsPath, template);
         updates.push(aiInstructionsExists ? "Updated .devflow/AI_INSTRUCTIONS.md" : "Created .devflow/AI_INSTRUCTIONS.md");
+      }
+    }
+
+    // Update Claude Code wrapper skill
+    const skillDir = resolve(cwd, ".claude/skills/devflow-usage");
+    const skillPath = resolve(skillDir, "SKILL.md");
+    const skillExists = existsSync(skillPath);
+
+    let updateSkill = true;
+    if (skillExists && !options.yes) {
+      const result = await confirmWithBack({
+        message: "Update .claude/skills/devflow-usage/SKILL.md with latest template?",
+        default: true,
+        showBack: false,
+      });
+      updateSkill = result === true;
+    }
+
+    if (updateSkill) {
+      let skillTemplate = CLAUDE_SKILL_TEMPLATE;
+      if (config.commitFormat) {
+        skillTemplate = skillTemplate.replace(
+          "{type}[{ticket}]{breaking}({scope}): {message}",
+          config.commitFormat
+        );
+      }
+      if (config.branchFormat) {
+        skillTemplate = skillTemplate.replace(
+          "{type}/{ticket}_{description}",
+          config.branchFormat
+        );
+      }
+
+      if (options.dryRun) {
+        console.log(dim(`[dry-run] Would ${skillExists ? "update" : "create"} .claude/skills/devflow-usage/SKILL.md`));
+      } else {
+        mkdirSync(skillDir, { recursive: true });
+        writeFileSync(skillPath, skillTemplate);
+        updates.push(skillExists ? "Updated .claude/skills/devflow-usage/SKILL.md" : "Created .claude/skills/devflow-usage/SKILL.md");
       }
     }
 

--- a/src/devflow-version.ts
+++ b/src/devflow-version.ts
@@ -7,6 +7,7 @@ interface DevflowVersionInfo {
   generatedAt: string;
   files: {
     aiInstructions?: string;
+    claudeSkill?: string;
   };
 }
 
@@ -35,6 +36,7 @@ export function writeVersionInfo(cliVersion: string, cwd: string = process.cwd()
     generatedAt: new Date().toISOString(),
     files: {
       aiInstructions: cliVersion,
+      claudeSkill: cliVersion,
     },
   };
   writeFileSync(versionPath, JSON.stringify(info, null, 2) + "\n");


### PR DESCRIPTION
## Summary

devflow init and devflow update now generate a Claude Code wrapper skill at .claude/skills/devflow-usage/SKILL.md alongside AI_INSTRUCTIONS.md. The skill surfaces devflow rules in Claude's skills list for discoverability while AI_INSTRUCTIONS.md stays the canonical agent-agnostic reference for Cursor, Copilot, etc. Both files sync via devflow update.

- feat[UNTRACKED](core): generate Claude Code wrapper skill via init/update
- docs[UNTRACKED](core): sync all documentation surfaces with current codebase
- chore[UNTRACKED](core): add docs-sync Claude Code skill
- fix[UNTRACKED](pr): handle merged and closed PRs gracefully

## Ticket

UNTRACKED

## Type of Change

- [ ] Feature (new functionality)
- [x] Bug fix (non-breaking fix)
- [ ] Refactor (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (deps, CI, configs, docs)

## Screenshots

<!-- Add before/after screenshots for UI changes, or remove this section if not applicable -->

| Before | After |
|--------|-------|
|        |       |

## Test Plan

- [ ] <!-- Add testing steps -->

## Checklist

- [ ] Code follows project conventions
- [ ] Self-reviewed the changes
- [ ] No new warnings or errors introduced