### PR TITLE
feat(docs): apply Pebble brand to VitePress site

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,10 +5,22 @@ export default defineConfig({
   description: 'Interactive CLI for branch creation, conventional commits, and PR management',
 
   head: [
-    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:title', content: 'devflow — stay in the flow.' }],
+    ['meta', { property: 'og:description', content: 'A guided CLI for branches, conventional commits, and PRs. devflow runs the workflow your team already agreed on.' }],
+    ['meta', { property: 'og:url', content: 'https://devflow.alejandrochaves.dev' }],
+    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    ['meta', { name: 'twitter:title', content: 'devflow — stay in the flow.' }],
+    ['meta', { name: 'twitter:description', content: 'A guided CLI for branches, conventional commits, and PRs.' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
+    ['link', { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Geist:ital,wght@0,400;0,500;0,600;0,700;0,800;1,500;1,600;1,700;1,800&family=JetBrains+Mono:wght@400;500;600&display=swap' }],
   ],
 
   themeConfig: {
+    logo: { light: '/logo-mark.svg', dark: '/logo-mark.svg' },
+
     nav: [
       { text: 'Getting Started', link: '/getting-started' },
       { text: 'Commands', link: '/commands/branch' },

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import DefaultTheme from 'vitepress/theme'
+import { useData } from 'vitepress'
+import PebbleCard from './components/PebbleCard.vue'
+import HomeHeroInfo from './components/HomeHeroInfo.vue'
+import TerminalDemo from './components/TerminalDemo.vue'
+import Commands from './components/Commands.vue'
+import CtaCard from './components/CtaCard.vue'
+
+const { Layout } = DefaultTheme
+const { frontmatter } = useData()
+const isHome = frontmatter.value.layout === 'home'
+</script>
+
+<template>
+  <Layout>
+    <template v-if="isHome" #home-hero-info>
+      <HomeHeroInfo />
+    </template>
+    <template v-if="isHome" #home-hero-image>
+      <PebbleCard />
+    </template>
+    <template v-if="isHome" #home-features-after>
+      <TerminalDemo />
+      <Commands />
+      <CtaCard />
+    </template>
+  </Layout>
+</template>

--- a/docs/.vitepress/theme/components/Commands.vue
+++ b/docs/.vitepress/theme/components/Commands.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+const cmds = [
+  { c: 'devflow init',     d: 'set up config, husky, commitlint, scripts' },
+  { c: 'devflow branch',   d: 'consistent type/TICKET_description naming' },
+  { c: 'devflow commit',   d: 'guided conventional commit' },
+  { c: 'devflow pr',       d: 'auto-filled PR template + auto labels' },
+  { c: 'devflow release',  d: 'version bump, changelog, tag, gh release' },
+  { c: 'devflow review',   d: 'list, approve, comment on open PRs' },
+  { c: 'devflow issue',    d: 'scrum-style issue with branch hand-off' },
+  { c: 'devflow stash',    d: 'named stashes, interactive' },
+  { c: 'devflow worktree', d: 'manage parallel worktrees' },
+  { c: 'devflow log',      d: 'interactive commit history + actions' },
+  { c: 'devflow stats',    d: 'commit pattern analytics' },
+  { c: 'devflow doctor',   d: 'verify git, gh, husky, hooks, config' },
+]
+</script>
+
+<template>
+  <section class="vp-section">
+    <div class="vp-section-head">
+      <span class="vp-mono-tag">COMMAND SURFACE</span>
+      <h2 class="vp-section-title">Every command, one short flag.</h2>
+      <p class="vp-section-sub">
+        Aliases are one or two letters. <code>devflow b</code>, <code>c</code>, <code>p</code>, <code>rel</code>, <code>i</code>, <code>st</code>…
+      </p>
+    </div>
+    <div class="vp-cmd-grid">
+      <div v-for="cmd in cmds" :key="cmd.c" class="vp-cmd">
+        <div class="vp-cmd-line">
+          <span class="vp-acc">$</span>
+          <span class="vp-cmd-name"> {{ cmd.c }}</span>
+        </div>
+        <div class="vp-cmd-d">{{ cmd.d }}</div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/docs/.vitepress/theme/components/CtaCard.vue
+++ b/docs/.vitepress/theme/components/CtaCard.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import Pebble from './Pebble.vue'
+</script>
+
+<template>
+  <section class="vp-cta">
+    <div class="vp-cta-inner">
+      <Pebble :size="120" expression="wow" class="vp-pebble-bob" />
+      <h2>Ready to give git a hand?</h2>
+      <p>
+        Install devflow and run <code>npx devflow init</code> —
+        you'll be on a clean conventional commit in 60 seconds.
+      </p>
+      <div class="vp-hero-cta">
+        <a class="vp-btn vp-btn-primary" href="/getting-started">Install →</a>
+        <a class="vp-btn vp-btn-ghost" href="https://github.com/alejandrochvs/devflow-cli">Star on GitHub</a>
+      </div>
+    </div>
+  </section>
+</template>

--- a/docs/.vitepress/theme/components/HomeHeroInfo.vue
+++ b/docs/.vitepress/theme/components/HomeHeroInfo.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+const copied = ref(false)
+const installCmd = 'npm i -D @alejandrochaves/devflow-cli'
+
+function copy() {
+  navigator.clipboard.writeText(installCmd).then(() => {
+    copied.value = true
+    setTimeout(() => { copied.value = false }, 1800)
+  })
+}
+</script>
+
+<template>
+  <div class="vp-hero-custom">
+    <div class="vp-hero-eyebrow">
+      <span class="vp-pulse" aria-hidden="true" />
+      <span>v1.8.0 — release flow shipped</span>
+    </div>
+    <h1 class="vp-hero-title">
+      stay in<br />
+      the <span class="vp-hero-accent">flow.</span>
+    </h1>
+    <p class="vp-hero-tagline">
+      A guided CLI for branches, conventional commits, and PRs.<br />
+      devflow runs the workflow your team already agreed on — so you can keep building.
+    </p>
+    <div class="vp-hero-cta">
+      <a class="vp-btn vp-btn-primary" href="/getting-started">Get started →</a>
+      <button class="vp-btn vp-btn-ghost vp-btn-mono" @click="copy" :title="copied ? 'Copied!' : 'Copy install command'">
+        <span class="vp-btn-prompt">$</span>
+        <span>{{ installCmd }}</span>
+        <span class="vp-btn-copy">{{ copied ? '✓' : '⧉' }}</span>
+      </button>
+    </div>
+    <div class="vp-hero-badges">
+      <a href="https://www.npmjs.com/package/@alejandrochaves/devflow-cli">
+        <img alt="npm" src="https://img.shields.io/npm/v/@alejandrochaves/devflow-cli?style=flat&color=ff9a3c&labelColor=1c1710&label=npm" />
+      </a>
+      <a href="https://www.npmjs.com/package/@alejandrochaves/devflow-cli">
+        <img alt="downloads" src="https://img.shields.io/npm/dm/@alejandrochaves/devflow-cli?style=flat&color=ff9a3c&labelColor=1c1710&label=downloads" />
+      </a>
+      <a href="https://github.com/alejandrochvs/devflow-cli">
+        <img alt="stars" src="https://img.shields.io/github/stars/alejandrochvs/devflow-cli?style=flat&color=ff9a3c&labelColor=1c1710&label=stars" />
+      </a>
+      <a href="https://github.com/alejandrochvs/devflow-cli/blob/main/LICENSE">
+        <img alt="MIT" src="https://img.shields.io/npm/l/@alejandrochaves/devflow-cli?style=flat&color=ff9a3c&labelColor=1c1710&label=license" />
+      </a>
+    </div>
+  </div>
+</template>

--- a/docs/.vitepress/theme/components/Pebble.vue
+++ b/docs/.vitepress/theme/components/Pebble.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+withDefaults(defineProps<{
+  size?: number
+  expression?: 'happy' | 'focused' | 'sleepy' | 'wow' | 'wink'
+  showBranch?: boolean
+  accent?: string
+  dark?: string
+  light?: string
+}>(), {
+  size: 200,
+  expression: 'happy',
+  showBranch: false,
+  accent: '#ff9a3c',
+  dark: '#1c1710',
+  light: '#fbe0bc',
+})
+</script>
+
+<template>
+  <svg :width="size" :height="size" viewBox="0 0 220 220" fill="none" style="overflow: visible">
+    <!-- head -->
+    <path
+      d="M 110 30 C 60 30, 36 60, 36 95 C 36 125, 50 145, 70 152 C 80 162, 95 168, 110 168 C 125 168, 140 162, 150 152 C 170 145, 184 125, 184 95 C 184 60, 160 30, 110 30 Z"
+      :fill="accent"
+    />
+    <!-- ears -->
+    <ellipse cx="58" cy="52" rx="11" ry="9" :fill="accent" />
+    <ellipse cx="162" cy="52" rx="11" ry="9" :fill="accent" />
+    <ellipse cx="58" cy="52" rx="5" ry="4" :fill="dark" />
+    <ellipse cx="162" cy="52" rx="5" ry="4" :fill="dark" />
+    <!-- eye patches -->
+    <ellipse cx="88" cy="96" rx="14" ry="13" :fill="light" opacity="0.55" />
+    <ellipse cx="132" cy="96" rx="14" ry="13" :fill="light" opacity="0.55" />
+    <!-- muzzle -->
+    <ellipse cx="110" cy="138" rx="38" ry="26" :fill="light" />
+    <!-- nose -->
+    <path d="M 100 122 Q 110 132, 120 122 Q 116 117, 110 116 Q 104 117, 100 122 Z" :fill="dark" />
+    <!-- philtrum -->
+    <line x1="110" y1="128" x2="110" y2="138" :stroke="dark" stroke-width="2" stroke-linecap="round" />
+    <!-- whisker dots -->
+    <circle cx="92" cy="134" r="1.4" :fill="dark" />
+    <circle cx="86" cy="140" r="1.4" :fill="dark" />
+    <circle cx="90" cy="146" r="1.4" :fill="dark" />
+    <circle cx="128" cy="134" r="1.4" :fill="dark" />
+    <circle cx="134" cy="140" r="1.4" :fill="dark" />
+    <circle cx="130" cy="146" r="1.4" :fill="dark" />
+    <!-- whiskers -->
+    <g :stroke="dark" stroke-width="1.2" stroke-linecap="round" opacity="0.55">
+      <line x1="86" y1="138" x2="68" y2="134" />
+      <line x1="86" y1="142" x2="66" y2="144" />
+      <line x1="134" y1="138" x2="152" y2="134" />
+      <line x1="134" y1="142" x2="154" y2="144" />
+    </g>
+
+    <!-- eyes: happy -->
+    <template v-if="expression === 'happy'">
+      <path d="M82 96 Q 88 90, 94 96" :stroke="dark" stroke-width="3.5" stroke-linecap="round" fill="none" />
+      <path d="M126 96 Q 132 90, 138 96" :stroke="dark" stroke-width="3.5" stroke-linecap="round" fill="none" />
+    </template>
+    <!-- eyes: focused -->
+    <template v-else-if="expression === 'focused'">
+      <circle cx="88" cy="96" r="4" :fill="dark" />
+      <circle cx="132" cy="96" r="4" :fill="dark" />
+      <circle cx="89" cy="94" r="1.4" :fill="light" />
+      <circle cx="133" cy="94" r="1.4" :fill="light" />
+    </template>
+    <!-- eyes: sleepy -->
+    <template v-else-if="expression === 'sleepy'">
+      <path d="M80 98 Q 88 96, 96 98" :stroke="dark" stroke-width="3" stroke-linecap="round" fill="none" />
+      <path d="M124 98 Q 132 96, 140 98" :stroke="dark" stroke-width="3" stroke-linecap="round" fill="none" />
+    </template>
+    <!-- eyes: wow -->
+    <template v-else-if="expression === 'wow'">
+      <circle cx="88" cy="96" r="6" :fill="dark" />
+      <circle cx="132" cy="96" r="6" :fill="dark" />
+      <circle cx="90" cy="94" r="1.8" :fill="light" />
+      <circle cx="134" cy="94" r="1.8" :fill="light" />
+    </template>
+    <!-- eyes: wink -->
+    <template v-else-if="expression === 'wink'">
+      <path d="M82 96 Q 88 90, 94 96" :stroke="dark" stroke-width="3.5" stroke-linecap="round" fill="none" />
+      <circle cx="132" cy="96" r="4" :fill="dark" />
+    </template>
+
+    <!-- mouth: happy -->
+    <template v-if="expression === 'happy' || expression === 'wink'">
+      <path d="M110 138 L 110 144 M 110 144 Q 102 148, 98 142 M 110 144 Q 118 148, 122 142" :stroke="dark" stroke-width="2.4" stroke-linecap="round" fill="none" />
+    </template>
+    <!-- mouth: focused -->
+    <template v-else-if="expression === 'focused'">
+      <path d="M104 144 L 116 144" :stroke="dark" stroke-width="2.4" stroke-linecap="round" />
+    </template>
+    <!-- mouth: sleepy -->
+    <template v-else-if="expression === 'sleepy'">
+      <path d="M104 144 Q 110 142, 116 144" :stroke="dark" stroke-width="2.4" stroke-linecap="round" fill="none" />
+    </template>
+    <!-- mouth: wow -->
+    <template v-else-if="expression === 'wow'">
+      <ellipse cx="110" cy="144" rx="3" ry="4" :fill="dark" />
+    </template>
+
+    <!-- branch (optional) -->
+    <template v-if="showBranch">
+      <ellipse cx="68" cy="178" rx="14" ry="10" fill="#d96d1f" />
+      <ellipse cx="152" cy="178" rx="14" ry="10" fill="#d96d1f" />
+      <line x1="56" y1="178" x2="164" y2="178" :stroke="dark" stroke-width="3" stroke-linecap="round" />
+      <circle cx="110" cy="178" r="6" :fill="accent" :stroke="dark" stroke-width="2.5" />
+      <circle cx="84" cy="178" r="4" :fill="dark" />
+      <circle cx="138" cy="178" r="4" :fill="dark" />
+    </template>
+  </svg>
+</template>

--- a/docs/.vitepress/theme/components/PebbleCard.vue
+++ b/docs/.vitepress/theme/components/PebbleCard.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+import Pebble from './Pebble.vue'
+
+const expression = ref<'happy' | 'focused' | 'sleepy' | 'wow' | 'wink'>('happy')
+const seq: Array<typeof expression.value> = ['happy', 'focused', 'wow', 'happy', 'wink', 'happy']
+let i = 0
+let timer: ReturnType<typeof setInterval>
+
+onMounted(() => {
+  timer = setInterval(() => {
+    i = (i + 1) % seq.length
+    expression.value = seq[i]
+  }, 1800)
+})
+
+onBeforeUnmount(() => clearInterval(timer))
+</script>
+
+<template>
+  <div class="vp-pebble-card">
+    <div class="vp-pebble-eyebrow">
+      <span class="vp-mono-tag">PEBBLE · DEVFLOW MASCOT</span>
+    </div>
+    <div class="vp-pebble-stage">
+      <Pebble :size="240" :expression="expression" :show-branch="true" class="vp-pebble-bob" />
+    </div>
+    <div class="vp-pebble-caption">
+      Otters hold hands so they don't drift apart while sleeping.<br />
+      <span class="vp-dim">devflow's the same idea, for your team.</span>
+    </div>
+  </div>
+</template>

--- a/docs/.vitepress/theme/components/TerminalDemo.vue
+++ b/docs/.vitepress/theme/components/TerminalDemo.vue
@@ -1,0 +1,35 @@
+<template>
+  <section class="vp-section">
+    <div class="vp-section-head">
+      <span class="vp-mono-tag">DEMO · GUIDED COMMIT</span>
+      <h2 class="vp-section-title">Type less. Ship in the same shape every time.</h2>
+      <p class="vp-section-sub">
+        devflow walks you through the commit, then formats it exactly to your team's convention.
+      </p>
+    </div>
+    <div class="vp-terminal">
+      <div class="vp-terminal-bar">
+        <span class="vp-tdot" style="background: #ff5f57" />
+        <span class="vp-tdot" style="background: #febc2e" />
+        <span class="vp-tdot" style="background: #28c840" />
+        <span class="vp-terminal-title">~/projects/checkout · feat/AUTH-204</span>
+      </div>
+      <div class="vp-terminal-body">
+        <div><span class="vp-acc">›</span> <strong>devflow commit</strong></div>
+        <div class="vp-tspace" />
+        <div><span class="vp-dim">?</span> <span class="vp-muted">Select files to stage</span> <span class="vp-dim">(2/4)</span></div>
+        <div>  <span class="vp-acc">◉</span> src/auth/login.ts</div>
+        <div>  <span class="vp-acc">◉</span> src/auth/session.ts</div>
+        <div>  <span class="vp-dim">◯ tests/auth.test.ts</span></div>
+        <div>  <span class="vp-dim">◯ CHANGELOG.md</span></div>
+        <div class="vp-tspace" />
+        <div><span class="vp-dim">?</span> <span class="vp-muted">Commit type</span> <span class="vp-acc">›</span> <strong>feat</strong> <span class="vp-dim">· a new feature</span></div>
+        <div><span class="vp-dim">?</span> <span class="vp-muted">Scope</span> <span class="vp-acc">›</span> <strong>auth</strong> <span class="vp-dim">· (inferred from src/auth/**)</span></div>
+        <div><span class="vp-dim">?</span> <span class="vp-muted">Subject</span> <span class="vp-acc">›</span> add biometric login<span class="vp-cursor" /></div>
+        <div class="vp-tspace" />
+        <div><span class="vp-dim">──── preview ────────────────────</span></div>
+        <div><span class="vp-acc-2">feat</span>[<span class="vp-warn">AUTH-204</span>](<span class="vp-acc-2">auth</span>): add biometric login</div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,5 @@
+import DefaultTheme from 'vitepress/theme'
+import Layout from './Layout.vue'
+import './style.css'
+
+export default { ...DefaultTheme, Layout }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,0 +1,525 @@
+/* devflow VitePress theme — Direction C: Otter / Pebble */
+
+/* Fonts are loaded via config.ts head to avoid render-blocking @import */
+
+/* ─── tokens — overwrite VitePress defaults ─────────────── */
+:root {
+  /* fonts */
+  --vp-font-family-base: 'Geist', system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+  --vp-font-family-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  /* brand palette */
+  --df-amber:     #ff9a3c;
+  --df-amber-2:   #ffb463;
+  --df-ember:     #d96d1f;
+  --df-ink:       #0f0c08;
+  --df-surface:   #1c1710;
+  --df-surface-2: #211a12;
+  --df-line:      #2a2218;
+  --df-line-2:    #3a2f20;
+  --df-cream:     #fbf3e4;
+  --df-muted:     #b09c7c;
+  --df-dim:       #6a5d47;
+  --df-warn:      #ffd166;
+  --df-danger:    #ef476f;
+
+  /* VitePress brand → amber */
+  --vp-c-brand-1:    #ff9a3c;
+  --vp-c-brand-2:    #ffb463;
+  --vp-c-brand-3:    #d96d1f;
+  --vp-c-brand-soft: rgba(255, 154, 60, 0.16);
+
+  /* button */
+  --vp-button-brand-bg:           #ff9a3c;
+  --vp-button-brand-hover-bg:     #ffb463;
+  --vp-button-brand-text:         #1c1710;
+  --vp-button-brand-border:       transparent;
+  --vp-button-brand-hover-border: transparent;
+  --vp-button-brand-active-bg:    #d96d1f;
+}
+
+/* dark mode (the brand is dark-first) */
+.dark {
+  --vp-c-bg:      #0f0c08;
+  --vp-c-bg-alt:  #15110b;
+  --vp-c-bg-soft: #1c1710;
+  --vp-c-bg-elv:  #1c1710;
+  --vp-c-divider: #2a2218;
+  --vp-c-border:  #2a2218;
+  --vp-c-text-1:  #fbf3e4;
+  --vp-c-text-2:  #b09c7c;
+  --vp-c-text-3:  #6a5d47;
+  --vp-c-gutter:  #15110b;
+}
+
+:root:not(.dark) {
+  --vp-c-bg:      #fdf9f1;
+  --vp-c-bg-alt:  #f8efdc;
+  --vp-c-bg-soft: #fbf3e4;
+  --vp-c-text-1:  #1c1710;
+  --vp-c-text-2:  #6a5d47;
+  --vp-c-text-3:  #b09c7c;
+  --vp-c-divider: #ead9b3;
+  --vp-c-border:  #ead9b3;
+}
+
+/* ─── home page hero ─────────────────────────────────────── */
+.VPHome { background: var(--vp-c-bg); }
+
+.VPHero .name,
+.VPHero .text {
+  font-style: italic;
+  font-weight: 800;
+  letter-spacing: -0.045em;
+  line-height: 0.96;
+}
+/* "stay in the" — cream, first line */
+.VPHero .name {
+  background: none !important;
+  -webkit-text-fill-color: var(--vp-c-text-1) !important;
+  color: var(--vp-c-text-1) !important;
+}
+/* "flow." — amber, second line */
+.VPHero .text {
+  color: var(--df-amber) !important;
+  -webkit-text-fill-color: var(--df-amber) !important;
+  background: none !important;
+}
+.VPHero .tagline {
+  font-style: normal;
+  font-weight: 400;
+  font-size: 18px;
+  color: var(--vp-c-text-2);
+  line-height: 1.55;
+}
+
+/* hero glow */
+.VPHero::before {
+  content: "";
+  position: absolute;
+  top: -200px; right: -100px;
+  width: 700px; height: 700px;
+  background: radial-gradient(circle, rgba(255,154,60,0.18), transparent 60%);
+  pointer-events: none;
+  z-index: 0;
+}
+.VPHero { position: relative; overflow: hidden; }
+.VPHero .container { position: relative; z-index: 1; }
+
+/* ─── nav brand wordmark ──────────────────────────────────── */
+.VPNavBarTitle .title {
+  font-style: italic;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  font-size: 19px;
+}
+.VPNavBarTitle .title::after {
+  content: ".";
+  color: var(--df-amber);
+}
+
+/* ─── feature cards ──────────────────────────────────────── */
+.VPFeatures .VPFeature {
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 16px;
+  padding: 28px;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+.VPFeatures .VPFeature:hover {
+  border-color: var(--df-line-2);
+  transform: translateY(-2px);
+}
+.VPFeatures .VPFeature .title {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.VPFeatures .VPFeature .icon {
+  background: var(--vp-c-bg-alt) !important;
+  border: 1px solid var(--df-line-2);
+  color: var(--df-amber);
+  border-radius: 10px;
+}
+
+/* ─── buttons ─────────────────────────────────────────────── */
+.VPButton {
+  border-radius: 100px !important;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  transition: transform 0.15s ease;
+}
+.VPButton:hover { transform: translateY(-1px); }
+.VPButton.brand {
+  font-weight: 700 !important;
+  box-shadow: 0 12px 28px -10px rgba(255,154,60,0.4);
+}
+
+/* ─── headings ────────────────────────────────────────────── */
+.vp-doc h1 {
+  font-style: italic;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+.vp-doc h2 {
+  font-style: italic;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+/* ─── code & inline code ──────────────────────────────────── */
+.vp-doc :not(pre) > code {
+  background: var(--df-surface);
+  color: var(--df-amber);
+  border: 1px solid var(--df-line);
+  font-size: 0.85em;
+}
+.dark .vp-doc :not(pre) > code {
+  background: var(--df-surface);
+}
+
+/* ─── sidebar ─────────────────────────────────────────────── */
+.VPSidebar .VPSidebarItem.is-active > .item .text {
+  color: var(--df-amber);
+}
+.VPSidebar .VPSidebarItem .text:hover { color: var(--df-amber); }
+
+/* ─────────────────────────────────────────────────────────── */
+/* HOME PAGE CUSTOM SECTIONS                                   */
+/* These classes are only used by components injected via      */
+/* the home-features-after and home-hero-image slots.         */
+/* ─────────────────────────────────────────────────────────── */
+
+/* section wrapper */
+.vp-section {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 80px 32px;
+  position: relative;
+}
+.vp-section-head {
+  max-width: 720px;
+  margin-bottom: 48px;
+}
+.vp-section-title {
+  font-family: 'Geist', sans-serif;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 44px;
+  letter-spacing: -0.035em;
+  line-height: 1.05;
+  margin: 12px 0 0;
+  color: var(--vp-c-text-1);
+  text-wrap: balance;
+}
+.vp-section-sub {
+  font-size: 17px;
+  color: var(--df-muted);
+  margin-top: 16px;
+  line-height: 1.55;
+  max-width: 600px;
+}
+.vp-section-sub code {
+  background: var(--df-surface);
+  padding: 1px 7px;
+  border-radius: 5px;
+  border: 1px solid var(--df-line);
+  font-size: 14px;
+  color: var(--df-amber);
+}
+.vp-mono-tag {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--df-dim);
+  text-transform: uppercase;
+}
+
+/* terminal */
+.vp-terminal {
+  background: var(--df-surface);
+  border: 1px solid var(--df-line);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 30px 80px -30px rgba(0,0,0,0.8);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+  line-height: 1.7;
+  max-width: 920px;
+}
+.vp-terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--df-line);
+  background: var(--df-surface-2);
+}
+.vp-tdot { width: 12px; height: 12px; border-radius: 50%; }
+.vp-terminal-title {
+  margin-left: auto;
+  margin-right: auto;
+  font-size: 11px;
+  color: var(--df-dim);
+  letter-spacing: 0.04em;
+  padding-right: 36px;
+}
+.vp-terminal-body {
+  padding: 22px 24px;
+  color: var(--vp-c-text-1);
+}
+.vp-tspace { height: 8px; }
+.vp-acc   { color: var(--df-amber); }
+.vp-acc-2 { color: var(--df-amber-2, #ffb463); }
+.vp-warn  { color: var(--df-warn); }
+.vp-muted { color: var(--df-muted); }
+.vp-dim   { color: var(--df-dim); }
+.vp-cursor {
+  display: inline-block;
+  width: 8px; height: 16px;
+  background: var(--df-amber);
+  margin-left: 3px;
+  vertical-align: -2px;
+  animation: vp-blink 1s steps(2) infinite;
+}
+@keyframes vp-blink { 0%,100% { opacity: 1 } 50% { opacity: 0 } }
+
+/* command grid */
+.vp-cmd-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+.vp-cmd {
+  background: var(--df-surface);
+  border: 1px solid var(--df-line);
+  border-radius: 10px;
+  padding: 16px 18px;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.vp-cmd:hover {
+  border-color: var(--df-line-2);
+  background: var(--df-surface-2);
+}
+.vp-cmd-line {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  color: var(--vp-c-text-1);
+  margin-bottom: 6px;
+}
+.vp-cmd-name { color: var(--vp-c-text-1); }
+.vp-cmd-d {
+  font-size: 13px;
+  color: var(--df-muted);
+}
+
+/* cta card */
+.vp-cta {
+  position: relative;
+  margin: 0 32px 60px;
+  padding: 80px 32px;
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(255,154,60,0.18), transparent 60%),
+    var(--df-surface);
+  border: 1px solid var(--df-line);
+  text-align: center;
+  overflow: hidden;
+}
+.vp-cta-inner {
+  max-width: 560px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.vp-cta-inner h2 {
+  font-family: 'Geist', sans-serif;
+  font-weight: 800;
+  font-style: italic;
+  font-size: 42px;
+  letter-spacing: -0.04em;
+  margin: 16px 0 14px;
+  color: var(--vp-c-text-1);
+  border: none !important;
+}
+.vp-cta-inner p {
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--df-muted);
+  margin: 0 0 28px;
+}
+.vp-cta-inner code {
+  background: var(--df-surface-2);
+  padding: 1px 7px;
+  border-radius: 5px;
+  border: 1px solid var(--df-line);
+  font-size: 14px;
+  color: var(--df-amber);
+}
+
+/* pebble card (hero right-side card) */
+.vp-pebble-card {
+  position: relative;
+  background: var(--df-surface);
+  border: 1px solid var(--df-line);
+  border-radius: 24px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 420px;
+  overflow: hidden;
+  box-shadow: 0 30px 80px -30px rgba(0,0,0,0.8);
+}
+.vp-pebble-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 60%, rgba(255,154,60,0.16), transparent 65%);
+  pointer-events: none;
+}
+.vp-pebble-eyebrow { position: relative; }
+.vp-pebble-stage {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
+  padding: 16px 0;
+}
+.vp-pebble-caption {
+  position: relative;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--df-muted);
+  text-align: center;
+}
+
+/* hero custom info panel */
+.vp-hero-custom {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+.vp-hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 14px;
+  background: var(--df-surface);
+  border: 1px solid var(--df-line);
+  border-radius: 100px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--df-muted);
+  margin-bottom: 28px;
+}
+.vp-pulse {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--df-amber);
+  box-shadow: 0 0 12px rgba(255,154,60,0.4);
+  animation: vp-pulse 2s ease-in-out infinite;
+}
+@keyframes vp-pulse { 0%,100%{opacity:1} 50%{opacity:0.45} }
+
+.vp-hero-title {
+  font-family: 'Geist', sans-serif;
+  font-weight: 800;
+  font-style: italic;
+  font-size: 86px;
+  letter-spacing: -0.05em;
+  line-height: 0.94;
+  margin: 0;
+  color: var(--vp-c-text-1);
+}
+.vp-hero-accent { color: var(--df-amber); }
+
+.vp-hero-tagline {
+  font-size: 18px;
+  line-height: 1.55;
+  color: var(--df-muted);
+  max-width: 480px;
+  margin-top: 28px;
+}
+
+.vp-hero-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 32px;
+}
+
+.vp-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 22px;
+  border-radius: 100px;
+  font-family: 'Geist', sans-serif;
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  border: 1px solid transparent;
+  text-decoration: none;
+  transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+.vp-btn:hover { transform: translateY(-1px); }
+.vp-btn:active { transform: translateY(0); }
+.vp-btn-primary {
+  background: var(--df-amber);
+  color: #1c1710;
+  box-shadow: 0 12px 28px -10px rgba(255,154,60,0.4);
+  font-weight: 700;
+}
+.vp-btn-primary:hover { background: var(--df-amber-2); }
+.vp-btn-ghost {
+  background: var(--df-surface);
+  color: var(--vp-c-text-1);
+  border-color: var(--df-line);
+}
+.vp-btn-ghost:hover {
+  border-color: var(--df-line-2);
+  background: var(--df-surface-2);
+}
+.vp-btn-mono {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  font-weight: 500;
+}
+.vp-btn-prompt { color: var(--df-amber); }
+.vp-btn-copy { color: var(--df-dim); margin-left: 4px; }
+
+.vp-hero-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 32px;
+}
+.vp-hero-badges img { height: 22px; opacity: 0.9; }
+
+/* pebble bob animation (shared) */
+@keyframes vp-bob {
+  0%,100% { transform: translateY(0) rotate(-1deg); }
+  50% { transform: translateY(-6px) rotate(1deg); }
+}
+.vp-pebble-bob {
+  animation: vp-bob 4s ease-in-out infinite;
+}
+
+/* responsive */
+@media (max-width: 1100px) {
+  .vp-hero-title { font-size: 64px; }
+  .vp-cmd-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 700px) {
+  .vp-hero-title { font-size: 48px; }
+  .vp-cmd-grid { grid-template-columns: 1fr; }
+  .vp-cta { margin: 0 16px 60px; }
+  .vp-section { padding: 60px 20px; }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,19 +2,7 @@
 layout: home
 
 hero:
-  name: devflow
-  text: Git workflows, simplified
-  tagline: Interactive CLI for branch creation, conventional commits, and PR management
-  actions:
-    - theme: brand
-      text: Get Started
-      link: /getting-started
-    - theme: alt
-      text: View on GitHub
-      link: https://github.com/alejandrochvs/devflow-cli
-    - theme: alt
-      text: Sponsor
-      link: https://github.com/sponsors/alejandrochvs
+  tagline: A guided CLI for branches, conventional commits, and PRs. devflow runs the workflow your team already agreed on — so you can keep building.
 
 features:
   - icon: 📝
@@ -36,15 +24,3 @@ features:
     title: Extensible
     details: Plugin system for custom commands. Auto-discovers devflow-plugin-* packages or configure explicitly.
 ---
-
-<div style="display: flex; justify-content: center; gap: 8px; margin-top: 24px;">
-  <a href="https://www.npmjs.com/package/@alejandrochaves/devflow-cli"><img src="https://img.shields.io/npm/dm/@alejandrochaves/devflow-cli" alt="npm downloads"></a>
-  <a href="https://www.npmjs.com/package/@alejandrochaves/devflow-cli"><img src="https://img.shields.io/npm/v/@alejandrochaves/devflow-cli" alt="npm version"></a>
-  <a href="https://github.com/alejandrochvs/devflow-cli"><img src="https://img.shields.io/github/stars/alejandrochvs/devflow-cli" alt="GitHub stars"></a>
-</div>
-
-<div style="margin-top: 48px; text-align: center;">
-  <h2 style="font-size: 1.5rem; margin-bottom: 16px;">See it in action</h2>
-  <p style="color: var(--vp-c-text-2); margin-bottom: 24px;">A complete workflow: create branch → commit → open PR</p>
-  <img src="/gifs/full-feature.gif" alt="devflow complete workflow demo" style="max-width: 800px; width: 100%; border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.2);" />
-</div>

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  
+  <rect width="32" height="32" rx="7" fill="#ff9a3c"></rect>
+  <ellipse cx="16" cy="20" rx="8" ry="6" fill="#fbe0bc"></ellipse>
+  <circle cx="11" cy="13" r="2.2" fill="#1c1710"></circle>
+  <circle cx="21" cy="13" r="2.2" fill="#1c1710"></circle>
+  <circle cx="11.5" cy="12.4" r="0.7" fill="#fbe0bc"></circle>
+  <circle cx="21.5" cy="12.4" r="0.7" fill="#fbe0bc"></circle>
+  <path d="M14 18 Q 16 20.5, 18 18 Q 17 16.6, 16 16.6 Q 15 16.6, 14 18 Z" fill="#1c1710"></path>
+  <line x1="16" y1="20" x2="16" y2="22" stroke="#1c1710" stroke-width="1.2" stroke-linecap="round"></line>
+</svg>

--- a/docs/public/logo-horizontal-dark.svg
+++ b/docs/public/logo-horizontal-dark.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 220" width="720" height="220">
+  
+  <rect width="720" height="220" fill="#0f0c08"></rect>
+  <g transform="translate(0,0)">
+    <path d="M 110 30 C 60 30, 36 60, 36 95 C 36 125, 50 145, 70 152 C 80 162, 95 168, 110 168 C 125 168, 140 162, 150 152 C 170 145, 184 125, 184 95 C 184 60, 160 30, 110 30 Z" fill="#ff9a3c"></path>
+    <ellipse cx="58" cy="52" rx="11" ry="9" fill="#ff9a3c"></ellipse>
+    <ellipse cx="162" cy="52" rx="11" ry="9" fill="#ff9a3c"></ellipse>
+    <ellipse cx="58" cy="52" rx="5" ry="4" fill="#1c1710"></ellipse>
+    <ellipse cx="162" cy="52" rx="5" ry="4" fill="#1c1710"></ellipse>
+    <ellipse cx="88" cy="96" rx="14" ry="13" fill="#fbe0bc" opacity="0.55"></ellipse>
+    <ellipse cx="132" cy="96" rx="14" ry="13" fill="#fbe0bc" opacity="0.55"></ellipse>
+    <ellipse cx="110" cy="138" rx="38" ry="26" fill="#fbe0bc"></ellipse>
+    <path d="M 100 122 Q 110 132, 120 122 Q 116 117, 110 116 Q 104 117, 100 122 Z" fill="#1c1710"></path>
+    <line x1="110" y1="128" x2="110" y2="138" stroke="#1c1710" stroke-width="2" stroke-linecap="round"></line>
+    <circle cx="92" cy="134" r="1.4" fill="#1c1710"></circle>
+    <circle cx="86" cy="140" r="1.4" fill="#1c1710"></circle>
+    <circle cx="90" cy="146" r="1.4" fill="#1c1710"></circle>
+    <circle cx="128" cy="134" r="1.4" fill="#1c1710"></circle>
+    <circle cx="134" cy="140" r="1.4" fill="#1c1710"></circle>
+    <circle cx="130" cy="146" r="1.4" fill="#1c1710"></circle>
+    <path d="M82 96 Q 88 90, 94 96" stroke="#1c1710" stroke-width="3.5" stroke-linecap="round" fill="none"></path>
+    <path d="M126 96 Q 132 90, 138 96" stroke="#1c1710" stroke-width="3.5" stroke-linecap="round" fill="none"></path>
+    <path d="M110 138 L 110 144 M 110 144 Q 102 148, 98 142 M 110 144 Q 118 148, 122 142" stroke="#1c1710" stroke-width="2.4" stroke-linecap="round" fill="none"></path>
+  </g>
+  <text x="240" y="124" font-family="Geist, Inter, system-ui, sans-serif" font-style="italic" font-weight="800" font-size="116" letter-spacing="-5" fill="#fbf3e4">devflow<tspan fill="#ff9a3c">.</tspan></text>
+</svg>

--- a/docs/public/logo-horizontal.svg
+++ b/docs/public/logo-horizontal.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 220" width="720" height="220">
+  
+  <g transform="translate(0,0)">
+    <path d="M 110 30 C 60 30, 36 60, 36 95 C 36 125, 50 145, 70 152 C 80 162, 95 168, 110 168 C 125 168, 140 162, 150 152 C 170 145, 184 125, 184 95 C 184 60, 160 30, 110 30 Z" fill="#ff9a3c"></path>
+    <ellipse cx="58" cy="52" rx="11" ry="9" fill="#ff9a3c"></ellipse>
+    <ellipse cx="162" cy="52" rx="11" ry="9" fill="#ff9a3c"></ellipse>
+    <ellipse cx="58" cy="52" rx="5" ry="4" fill="#1c1710"></ellipse>
+    <ellipse cx="162" cy="52" rx="5" ry="4" fill="#1c1710"></ellipse>
+    <ellipse cx="88" cy="96" rx="14" ry="13" fill="#fbe0bc" opacity="0.55"></ellipse>
+    <ellipse cx="132" cy="96" rx="14" ry="13" fill="#fbe0bc" opacity="0.55"></ellipse>
+    <ellipse cx="110" cy="138" rx="38" ry="26" fill="#fbe0bc"></ellipse>
+    <path d="M 100 122 Q 110 132, 120 122 Q 116 117, 110 116 Q 104 117, 100 122 Z" fill="#1c1710"></path>
+    <line x1="110" y1="128" x2="110" y2="138" stroke="#1c1710" stroke-width="2" stroke-linecap="round"></line>
+    <circle cx="92" cy="134" r="1.4" fill="#1c1710"></circle>
+    <circle cx="86" cy="140" r="1.4" fill="#1c1710"></circle>
+    <circle cx="90" cy="146" r="1.4" fill="#1c1710"></circle>
+    <circle cx="128" cy="134" r="1.4" fill="#1c1710"></circle>
+    <circle cx="134" cy="140" r="1.4" fill="#1c1710"></circle>
+    <circle cx="130" cy="146" r="1.4" fill="#1c1710"></circle>
+    <path d="M82 96 Q 88 90, 94 96" stroke="#1c1710" stroke-width="3.5" stroke-linecap="round" fill="none"></path>
+    <path d="M126 96 Q 132 90, 138 96" stroke="#1c1710" stroke-width="3.5" stroke-linecap="round" fill="none"></path>
+    <path d="M110 138 L 110 144 M 110 144 Q 102 148, 98 142 M 110 144 Q 118 148, 122 142" stroke="#1c1710" stroke-width="2.4" stroke-linecap="round" fill="none"></path>
+  </g>
+  <text x="240" y="124" font-family="Geist, Inter, system-ui, sans-serif" font-style="italic" font-weight="800" font-size="116" letter-spacing="-5" fill="#1c1710">devflow<tspan fill="#ff9a3c">.</tspan></text>
+</svg>

--- a/docs/public/logo-mark-ink.svg
+++ b/docs/public/logo-mark-ink.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 220" width="220" height="220">
+  
+  <path d="M 110 30 C 60 30, 36 60, 36 95 C 36 125, 50 145, 70 152 C 80 162, 95 168, 110 168 C 125 168, 140 162, 150 152 C 170 145, 184 125, 184 95 C 184 60, 160 30, 110 30 Z" fill="#1c1710"></path>
+  <ellipse cx="58" cy="52" rx="11" ry="9" fill="#1c1710"></ellipse>
+  <ellipse cx="162" cy="52" rx="11" ry="9" fill="#1c1710"></ellipse>
+  
+  <ellipse cx="110" cy="138" rx="38" ry="26" fill="#ff9a3c"></ellipse>
+  <path d="M 100 122 Q 110 132, 120 122 Q 116 117, 110 116 Q 104 117, 100 122 Z" fill="#1c1710"></path>
+  <line x1="110" y1="128" x2="110" y2="138" stroke="#1c1710" stroke-width="2" stroke-linecap="round"></line>
+  <path d="M82 96 Q 88 90, 94 96" stroke="#ff9a3c" stroke-width="3.5" stroke-linecap="round" fill="none"></path>
+  <path d="M126 96 Q 132 90, 138 96" stroke="#ff9a3c" stroke-width="3.5" stroke-linecap="round" fill="none"></path>
+  <path d="M110 138 L 110 144 M 110 144 Q 102 148, 98 142 M 110 144 Q 118 148, 122 142" stroke="#ff9a3c" stroke-width="2.4" stroke-linecap="round" fill="none"></path>
+</svg>

--- a/docs/public/logo-mark.svg
+++ b/docs/public/logo-mark.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 220" width="220" height="220">
+  
+  <path d="M 110 30 C 60 30, 36 60, 36 95 C 36 125, 50 145, 70 152 C 80 162, 95 168, 110 168 C 125 168, 140 162, 150 152 C 170 145, 184 125, 184 95 C 184 60, 160 30, 110 30 Z" fill="#ff9a3c"></path>
+  <ellipse cx="58" cy="52" rx="11" ry="9" fill="#ff9a3c"></ellipse>
+  <ellipse cx="162" cy="52" rx="11" ry="9" fill="#ff9a3c"></ellipse>
+  <ellipse cx="58" cy="52" rx="5" ry="4" fill="#1c1710"></ellipse>
+  <ellipse cx="162" cy="52" rx="5" ry="4" fill="#1c1710"></ellipse>
+  <ellipse cx="88" cy="96" rx="14" ry="13" fill="#fbe0bc" opacity="0.55"></ellipse>
+  <ellipse cx="132" cy="96" rx="14" ry="13" fill="#fbe0bc" opacity="0.55"></ellipse>
+  <ellipse cx="110" cy="138" rx="38" ry="26" fill="#fbe0bc"></ellipse>
+  <path d="M 100 122 Q 110 132, 120 122 Q 116 117, 110 116 Q 104 117, 100 122 Z" fill="#1c1710"></path>
+  <line x1="110" y1="128" x2="110" y2="138" stroke="#1c1710" stroke-width="2" stroke-linecap="round"></line>
+  <circle cx="92" cy="134" r="1.4" fill="#1c1710"></circle>
+  <circle cx="86" cy="140" r="1.4" fill="#1c1710"></circle>
+  <circle cx="90" cy="146" r="1.4" fill="#1c1710"></circle>
+  <circle cx="128" cy="134" r="1.4" fill="#1c1710"></circle>
+  <circle cx="134" cy="140" r="1.4" fill="#1c1710"></circle>
+  <circle cx="130" cy="146" r="1.4" fill="#1c1710"></circle>
+  <g stroke="#1c1710" stroke-width="1.2" stroke-linecap="round" opacity="0.55">
+    <line x1="86" y1="138" x2="68" y2="134"></line>
+    <line x1="86" y1="142" x2="66" y2="144"></line>
+    <line x1="134" y1="138" x2="152" y2="134"></line>
+    <line x1="134" y1="142" x2="154" y2="144"></line>
+  </g>
+  <path d="M82 96 Q 88 90, 94 96" stroke="#1c1710" stroke-width="3.5" stroke-linecap="round" fill="none"></path>
+  <path d="M126 96 Q 132 90, 138 96" stroke="#1c1710" stroke-width="3.5" stroke-linecap="round" fill="none"></path>
+  <path d="M110 138 L 110 144 M 110 144 Q 102 148, 98 142 M 110 144 Q 118 148, 122 142" stroke="#1c1710" stroke-width="2.4" stroke-linecap="round" fill="none"></path>
+</svg>


### PR DESCRIPTION
## Summary

- **Pebble otter mascot** (Direction C from Claude Design handoff) wired into VitePress via the slot system — keeps the automated docs workflow fully intact
- **Amber + ink palette**, Geist + JetBrains Mono fonts, italic display type applied globally via `docs/.vitepress/theme/style.css`
- **Custom home sections** injected via `home-hero-info`, `home-hero-image`, and `home-features-after` slots:
  - Animated Pebble card (cycles 5 expressions every 1.8s) in the hero right-side
  - Custom hero text: *"stay in the flow."* with amber accent + copy-install button + badges
  - Terminal demo with ambient commit flow
  - 12-command grid
  - CTA card with Pebble + install prompt
- **5 SVG brand assets** added to `docs/public/` (mark, horizontal lockups, ink variant, favicon)
- Doc pages untouched: custom home sections only render in the `home-*` slots

## What's deferred

- OG card / README banner PNGs (need headless screenshot step)
- Light-mode polish (rough variant ships as-is; designer flagged it as a follow-up)

## Test plan

- [x] `npm run docs:build` exits 0 (no SSR/hydration errors)
- [x] 174 unit tests pass
- [x] Home page: Pebble card, italic hero, amber palette, terminal demo, command grid, CTA visible
- [x] Doc page (`/commands/branch`): amber active sidebar, italic headings, amber code tokens, no home section leakage
- [ ] Vercel preview — confirm at the PR preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)