### PR TITLE
fix(docs): fix mobile hero layout overflow

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -27,3 +27,54 @@ const isHome = frontmatter.value.layout === 'home'
     </template>
   </Layout>
 </template>
+
+<style scoped>
+/*
+ * On mobile, VitePress's .main is a flex item with flex-shrink:0 and
+ * min-width:auto. The install button's default white-space:nowrap sets
+ * a wide min-content that expands .main beyond the viewport.
+ * :deep() pierces VitePress scoped CSS (higher specificity than their
+ * [data-v-xxx] attribute selector), forcing min-width:0 so the cross-axis
+ * stretch alignment can properly constrain .main to the container width.
+ */
+@media (max-width: 959px) {
+  :deep(.vp-pebble-caption),
+  :deep(.vp-mono-tag) {
+    display: none;
+  }
+  :deep(.VPHero .image-container) {
+    width: 100%;
+    height: auto;
+    max-height: 220px;
+    overflow: hidden;
+  }
+  :deep(.VPHero .main) {
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
+  }
+  :deep(.VPHero .main .vp-hero-tagline) {
+    max-width: 100%;
+    width: 100%;
+    word-break: break-word;
+  }
+  :deep(.VPHero .main .vp-hero-cta) {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+  :deep(.VPHero .main .vp-btn) {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    justify-content: center;
+    overflow: hidden;
+  }
+  :deep(.VPHero .main .vp-install-text) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/components/HomeHeroInfo.vue
+++ b/docs/.vitepress/theme/components/HomeHeroInfo.vue
@@ -23,14 +23,14 @@ function copy() {
       the <span class="vp-hero-accent">flow.</span>
     </h1>
     <p class="vp-hero-tagline">
-      A guided CLI for branches, conventional commits, and PRs.<br />
+      A guided CLI for branches, conventional commits, and PRs.
       devflow runs the workflow your team already agreed on — so you can keep building.
     </p>
     <div class="vp-hero-cta">
       <a class="vp-btn vp-btn-primary" href="/getting-started">Get started →</a>
       <button class="vp-btn vp-btn-ghost vp-btn-mono" @click="copy" :title="copied ? 'Copied!' : 'Copy install command'">
         <span class="vp-btn-prompt">$</span>
-        <span>{{ installCmd }}</span>
+        <span class="vp-install-text">{{ installCmd }}</span>
         <span class="vp-btn-copy">{{ copied ? '✓' : '⧉' }}</span>
       </button>
     </div>
@@ -50,3 +50,34 @@ function copy() {
     </div>
   </div>
 </template>
+
+<style scoped>
+/*
+ * On mobile, VitePress's .main flex item has min-width:auto which prevents
+ * shrinking below content width. Switching to block layout here makes every
+ * child a normal block element that fills 100% parent width without flex
+ * minimum-size semantics — the most reliable cross-browser fix.
+ */
+@media (max-width: 959px) {
+  .vp-hero-custom {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  .vp-hero-cta {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    margin-top: 24px;
+  }
+  .vp-btn {
+    width: 100%;
+    justify-content: center;
+    box-sizing: border-box;
+  }
+  .vp-hero-badges {
+    justify-content: center;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -517,9 +517,67 @@
   .vp-hero-title { font-size: 64px; }
   .vp-cmd-grid { grid-template-columns: repeat(2, 1fr); }
 }
+
+/* tablet / stacked hero — pebble card compacts, caption hidden */
+@media (max-width: 959px) {
+  /*
+   * VitePress applies margin:-76px -24px -48px to .VPHero .image on mobile
+   * so the image bleeds over the hero text as a decorative background.
+   * Our PebbleCard is a solid UI card, not a background image — reset the
+   * bleed so it stacks cleanly above the hero text.
+   * Specificity: .VPHero .image (0,2,0) = .image[data-v-xxx] (0,2,0);
+   * our rule wins because it's declared later in the cascade.
+   */
+  .VPHero .image {
+    margin: 0;
+  }
+  .VPHero .image-container {
+    width: auto;
+    height: auto;
+  }
+
+  .vp-pebble-card {
+    min-height: auto;
+    padding: 16px 20px 20px;
+    border-radius: 16px;
+  }
+  .vp-pebble-caption { display: none; }
+  .vp-pebble-stage { padding: 8px 0; }
+  .vp-pebble-stage svg { width: 160px; height: 160px; }
+  /*
+   * Use viewport-relative max-width so the constraint is absolute and
+   * bypasses the min-width:auto cascade through .main → .vp-hero-custom
+   * → flex items. 48px = VPHero's 24px left + 24px right padding.
+   */
+  .vp-hero-custom {
+    max-width: calc(100vw - 48px);
+    box-sizing: border-box;
+    overflow: hidden;
+  }
+  .vp-hero-tagline,
+  .vp-hero-title {
+    max-width: calc(100vw - 48px);
+  }
+}
+
 @media (max-width: 700px) {
   .vp-hero-title { font-size: 48px; }
   .vp-cmd-grid { grid-template-columns: 1fr; }
   .vp-cta { margin: 0 16px 60px; }
   .vp-section { padding: 60px 20px; }
+  /* CTA row: stack vertically so neither button overflows on narrow screens */
+  .vp-hero-cta {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .vp-hero-cta .vp-btn {
+    width: 100%;
+    justify-content: center;
+  }
+  /* truncate install command text to prevent button overflow */
+  .vp-btn-mono .vp-install-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes text/button horizontal overflow on mobile viewports using `:deep()` in `Layout.vue` to pierce VitePress's scoped CSS attribute-selector specificity
- Hides Pebble card label (`.vp-mono-tag`) on mobile to clean up the hero card
- Constrains Pebble card height to 220px max on mobile
- Stacks CTA buttons vertically and truncates install command text on narrow screens

## Root cause
VitePress's `.main` flex item has `flex-shrink: 0` + `min-width: auto`. The install button's default browser `white-space: nowrap` set a wide min-content that expanded `.main` beyond the 390px viewport. External CSS couldn't override because VitePress injects scoped styles dynamically (always after global CSS), making its `[data-v-xxx]` rules win in cascade order.

## Fix
`:deep(.VPHero .main)` in a `<style scoped>` block on `Layout.vue` generates `[data-v-Layout] .VPHero .main` — which beats VitePress's `[data-v-VPHero] .main` in specificity (ancestor attribute + two descendant classes vs one class + one attribute).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)